### PR TITLE
Make better use of parallelism in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           - run:
               name: py.test
               command: |
-                . venv36/bin/activate
+                . venv27/bin/activate
                 pip install -e .
                 circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename| xargs -n 1 py.test --junit-xml=reports/unitests.xml $test
           - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
                 . venv36/bin/activate
                 pip install -e .
                 py.test --junit-xml=reports/unittests.xml tests/__init__.py
-                circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename | xargs -n 1 py.test --junit-xml=reports/unittests.xml
+                circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename | xargs -n 1 py.test --junit-xml=reports/
           - store_artifacts:
               path: reports/
               destination: tr36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
               command: |
                 . venv36/bin/activate
                 pip install -e .
-                py.test --junit-xml=reports/unittests.xml tests/__init__.py
+                #py.test --junit-xml=reports/unittests.xml tests/__init__.py
                 n=0
                 for test in $(circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename) ;do
                   py.test --junit-xml=reports/unittest_$n.xml $test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,7 @@ jobs:
               command: |
                 . venv36/bin/activate
                 pip install -e .
-                #py.test --junit-xml=reports/unittests.xml tests/__init__.py
-                n=0
-                for test in $(circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename) ;do
-                  py.test --junit-xml=reports/unittest_$n.xml $test
-                  n=n+1
-                done
+                circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename| xargs -n 1 py.test --junit-xml=reports/ $test
           - store_artifacts:
               path: reports/
               destination: tr36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
               command: |
                 . venv36/bin/activate
                 pip install -e .
-                circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename| xargs -n 1 py.test --junit-xml=reports/ $test
+                circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename| xargs -n 1 py.test --junit-xml=reports/unitests.xml $test
           - store_artifacts:
               path: reports/
               destination: tr36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       - image: circleci/python:3.6.2
     environment:
       TZ: "/usr/share/zoneinfo/Europe/Amsterdam"
+    parallelism: 4
     steps:
           - checkout
           - restore_cache:
@@ -23,7 +24,8 @@ jobs:
               command: |
                 . venv36/bin/activate
                 pip install -e .
-                py.test --junit-xml=reports/unittests.xml
+                py.test --junit-xml=reports/unittests.xml tests/__init__.py
+                circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename | xargs -n 1 py.test --junit-xml=reports/unittests.xml
           - store_artifacts:
               path: reports/
               destination: tr36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
               paths:
                 - "venv36"
           - run:
+              name: py.test
               command: |
                 . venv36/bin/activate
                 pip install -e .
@@ -50,10 +51,11 @@ jobs:
               paths:
                 - "venv27"
           - run:
+              name: py.test
               command: |
-                . venv27/bin/activate
+                . venv36/bin/activate
                 pip install -e .
-                py.test --junit-xml=reports/unittests.xml
+                circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename| xargs -n 1 py.test --junit-xml=reports/unitests.xml $test
           - store_artifacts:
               path: reports/
               destination: tr27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,9 @@ jobs:
               command: |
                 . venv36/bin/activate
                 pip install -e .
-                circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename| xargs -n 1 py.test --junit-xml=reports/unitests.xml $test
+                for t in $(circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename); do
+                  py.test --junit-xml=reports/$t.xml $t
+                done
           - store_artifacts:
               path: reports/
               destination: tr36
@@ -56,7 +58,9 @@ jobs:
               command: |
                 . venv27/bin/activate
                 pip install -e .
-                circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename| xargs -n 1 py.test --junit-xml=reports/unitests.xml $test
+                for t in $(circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename); do
+                  py.test --junit-xml=reports/$t.xml $t
+                done
           - store_artifacts:
               path: reports/
               destination: tr27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,11 @@ jobs:
                 . venv36/bin/activate
                 pip install -e .
                 py.test --junit-xml=reports/unittests.xml tests/__init__.py
-                circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename | xargs -n 1 py.test --junit-xml=reports/
+                n=0
+                for test in $(circleci tests glob tests/test_* | circleci tests split --split-by=timings --timings-type=filename) ;do
+                  py.test --junit-xml=reports/unittest_$n.xml $test
+                  n=n+1
+                done
           - store_artifacts:
               path: reports/
               destination: tr36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
       - image: circleci/python:2.7.13
     environment:
       TZ: "/usr/share/zoneinfo/Europe/Amsterdam"
+    parallelism: 4
     steps:
           - checkout
           - restore_cache:


### PR DESCRIPTION
Unfortunatly the step 'store_test_results' doesn't work when you use parallel builds. So you are loosing some functionality there.